### PR TITLE
Adds a German translation

### DIFF
--- a/locale/de/de.cfg
+++ b/locale/de/de.cfg
@@ -1,0 +1,66 @@
+[item-name]
+dect-base-dirt=Erde
+dect-base-sand=Sand
+dect-base-sand-dark=Dunkler Sand
+dect-base-grass=Gras
+dect-base-grass-dry=Trockenes Gras
+dect-base-red-desert=Rote Wüste
+dect-base-red-desert-dark=Dunkle rote Wüste
+dect-base-water=Wasser
+dect-base-water-green=Grünes Wasser
+dect-paint-hazard=Beton mit Gefahrenmarkierung
+dect-paint-emergency=Beton mit Notfallmarkierung
+dect-paint-radiation=Beton mit Strahlungswarnung
+dect-paint-safety=Beton mit Sicherheitsmarkierung
+dect-paint-caution=Beton mit Warnungsmarkierung
+dect-paint-danger=Beton mit Gefahrenmarkierung
+dect-paint-defect=Beton mit Beschädigung
+dect-paint-operations=Beton mit Betriebsmarkierung
+dect-wood-floor=Holzboden
+
+[item-description]
+dect-paint-hazard=Drücke __CONTROL__rotate__ um bemalte Kacheln zu drehen.
+dect-paint-emergency=Drücke __CONTROL__rotate__ um bemalte Kacheln zu drehen.
+dect-paint-radiation=Drücke __CONTROL__rotate__ um bemalte Kacheln zu drehen.
+dect-paint-safety=Drücke __CONTROL__rotate__ um bemalte Kacheln zu drehen.
+dect-paint-caution=Drücke __CONTROL__rotate__ um bemalte Kacheln zu drehen.
+dect-paint-danger=Drücke __CONTROL__rotate__ um bemalte Kacheln zu drehen.
+dect-paint-defect=Drücke __CONTROL__rotate__ um bemalte Kacheln zu drehen.
+dect-paint-operations=Drücke __CONTROL__rotate__ um bemalte Kacheln zu drehen.
+
+[recipe-name]
+dect-concrete-wall-from-stone-wall=Betonmauer aus Steinmauer
+
+[entity-name]
+dect-wood-wall=Holzbarrikade
+dect-chain-wall=Maschendrahtzaun
+dect-concrete-wall=Betonmauer
+dect-hazard-gate=Tor mit Gefahrenmarkierung
+
+[tile-name]
+dect-paint-hazard-left=Beton mit Gefahrenmarkierung
+dect-paint-emergency-left=Beton mit Notfallmarkierung
+dect-paint-radiation-left=Beton mit Strahlungswarnung
+dect-paint-safety-left=Beton mit Sicherheitsmarkierung
+dect-paint-caution-left=Beton mit Warnungsmarkierung
+dect-paint-danger-left=Beton mit Gefahrenmarkierung
+dect-paint-defect-left=Beton mit Beschädigung
+dect-paint-operations-left=Beton mit Betriebsmarkierung
+dect-wood-floor=Holzboden
+dect-gravel=Kies
+
+[technology-name]
+dect-landscaping=Landschaftsgestaltung
+dect-concrete-paint=Bemalter Beton
+stone-walls=Einfache Mauern
+dect-advanced-walls=Erweiterte Mauern
+dect-wood-floor=Holzboden
+landfill=Landaufschüttung
+
+[technology-description]
+dect-landscaping= Erlaubt es dir natürliche Bodenarten zu bauen.
+dect-concrete-paint=Bemale Betonoberflächen für mehr Dekoration.
+stone-walls=Einfache Mauern, die deine Fabrik vor Angreifern beschützen.
+dect-advanced-walls=Stabiler als einfache Mauern, machen deine Fabrik noch sicherer.
+dect-wood-floor=Einfacher Holzboden, der es dir ermöglicht schneller zu laufen.
+landfill=Erlaubt dir, Wasser hinzuzufügen und zu entfernen.

--- a/locale/de/notifications.cfg
+++ b/locale/de/notifications.cfg
@@ -1,0 +1,7 @@
+dect-notify-dectorio=Dectorio
+dect-notify-version=[__1__] Version __2__ installiert.
+dect-notify-newversion=[__1__] Aktualisiert von Version __2__ auf Version __3__.
+dect-notify-incompatible=[__1__] Warnung: Eine inkompatible Mod wurde gefunden!
+dect-notify-reason-signals=[__1__] Grund: '__2__' überschreibt Signaldaten. Es ist empfohlen, '__2__' zu deaktivieren.
+dect-notify-reason-tech=[__1__] Grund: '__2__' dupliziert Technologien, die bereits in Dectorio vorhanden sind. Es ist empfohlen, '__2__' zu deaktivieren.
+dect-notify-modportal=[__1__] Gehe ins Mod-Portal für weitere Informationen.

--- a/locale/de/settings.cfg
+++ b/locale/de/settings.cfg
@@ -1,0 +1,13 @@
+[mod-setting-name]
+dectorio-signals=Aktiviere Signale
+dectorio-walls=Aktiviere Mauern und Tore
+dectorio-landscaping=Aktiviere Landschaftsgestaltung
+dectorio-flooring=Aktiviere Böden
+dectorio-painted-concrete=Aktiviere bemalten Beton
+
+[mod-setting-description]
+dectorio-signals=Aktiviert zusätzliche Signale für Lampen und Schaltungsnetze
+dectorio-walls=Aktiviert zusätzliche Arten von Mauern und Toren
+dectorio-landscaping=Aktiviert die Möglichkeit, Sand, Erde, Gras, rote Wüste und Wasser herzustellen
+dectorio-flooring=Aktiviert die Möglichkeit, Bodentypen wie Holzboden und Kies herzustellen
+dectorio-painted-concrete=Aktiviert bemalte Betontypen, die den normalen Beton mit Gefahrenmarkierung ersetzen

--- a/locale/de/signals.cfg
+++ b/locale/de/signals.cfg
@@ -1,0 +1,14 @@
+[virtual-signal-name]
+signal-red=Rotes Signal
+signal-orange=Oranges Signal
+signal-tangerine=Orangerotes Signal
+signal-yellow=Gelbes Signal
+signal-green=Grünes Signal
+signal-cyan=Zyanblaues Signal
+signal-aqua=Türkises Signal
+signal-blue=Blaues Signal
+signal-purple=Lila Signal
+signal-pink=Rosa Signal
+signal-white=Weißes Signal
+signal-grey=Graues Signal
+signal-black=Schwarzes Signal


### PR DESCRIPTION
I used the official German Factorio translation as a guideline how to
translate certain words. Some I had to make up on the way, some
(especially the types of concrete) might be a bit clunky, but they at
least fit the style Factorio used for their hazard concrete.

Interesting fact: German does not have a direct word for Tangerine.
Apparently, "orangerot" (orange-red) is the best translation.