### PR TITLE
Hazard fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The latest stable release is available at <https://github.com/jpanther/Dectorio/releases/latest>
 
+## v0.5.15 - unreleased (coming soon)
+
+### Bugfixes
+* Base Hazard Concrete is now correctly made available for crafting on saves if Dectorio is later removed
+
 ## v0.5.14 - 2017-07-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,6 +100,6 @@ Refer to the [CHANGELOG](CHANGELOG.md) for a detailed list of changes in each ve
 Developed with ❤ by [James Panther](https://github.com/jpanther) in Melbourne, Australia.
 Special thanks to marcfj for support and playtesting.
 
-## Translators
+#### Translators
 
 German translation by [seeba8](https://github.com/seeba8).

--- a/control.lua
+++ b/control.lua
@@ -170,6 +170,20 @@ local function on_configuration_changed(data)
     end
 end
 
+local function on_research_finished(event)
+	init_global()
+
+	-- Manually unlock vanilla hazard concrete because the recipe is hidden and will break saves if the mod is later removed
+	if DECT.CONFIG["disable_hazard_concrete"] then
+		for _, next_force in pairs(game.forces) do
+			force = next_force
+			if event.research.name == "concrete" then
+				force.recipes["hazard-concrete"].enabled = true
+			end
+		end
+	end
+end
+
 -- Fire events!
 script.on_init(function(data)
     on_init(data)
@@ -177,4 +191,8 @@ end)
 
 script.on_configuration_changed(function(data)
     on_configuration_changed(data)
+end)
+
+script.on_event(defines.events.on_research_finished,function(event)
+	on_research_finished(event)
 end)

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "Dectorio",
-    "version": "0.5.14",
+    "version": "0.5.15",
     "title": "Dectorio",
     "author": "PantherX",
     "contact": "",

--- a/migrations/0.5.15.lua
+++ b/migrations/0.5.15.lua
@@ -1,0 +1,13 @@
+for index, force in pairs(game.forces) do
+
+	force.reset_recipes()
+	force.reset_technologies()
+
+	local tech = force.technologies
+	local rec = force.recipes
+
+	if tech["concrete"].researched then
+		rec["hazard-concrete"].enabled = true
+	end
+		
+end

--- a/prototypes/item/items.lua
+++ b/prototypes/item/items.lua
@@ -83,6 +83,11 @@ if DECT.ENABLED["painted-concrete"] then
 		})
 	end
 
+	-- Hide base hazard concrete item
+	if DECT.CONFIG["disable_hazard_concrete"] then
+		table.insert(data.raw.item["hazard-concrete"].flags,"hidden")
+	end
+
 end
 
 if DECT.ENABLED["wood-floor"] then

--- a/prototypes/recipe/recipes.lua
+++ b/prototypes/recipe/recipes.lua
@@ -157,7 +157,8 @@ if DECT.ENABLED["painted-concrete"] then
 
 	-- Disable base hazard concrete recipe
 	if DECT.CONFIG["disable_hazard_concrete"] then
-		data.raw["recipe"]["hazard-concrete"].enabled = false
+		local base_hazard_recipe = data.raw["recipe"]["hazard-concrete"]
+		base_hazard_recipe.hidden = true
 	end
 
 end

--- a/prototypes/technology/technology.lua
+++ b/prototypes/technology/technology.lua
@@ -154,11 +154,16 @@ if DECT.ENABLED["painted-concrete"] then
 	if DECT.CONFIG["disable_hazard_concrete"] then
 
 		-- Remove base Hazard concrete (as it's replaced by painted concrete)
-		data.raw["technology"]["concrete"].effects = {{
-		        type = "unlock-recipe",
-		        recipe = "concrete"
-		    }}
-		      
+		local base_concrete_effects = data.raw["technology"]["concrete"].effects
+		for i = 1, #base_concrete_effects do
+			effect = base_concrete_effects[i]
+			if effect.type == "unlock-recipe" and effect.recipe == "hazard-concrete" then
+				index = i
+			end
+		end
+		
+		table.remove(base_concrete_effects, index)
+
 	end
 
 end


### PR DESCRIPTION
Base Hazard Concrete is now correctly made available for crafting on saves if Dectorio is later removed