### PR TITLE
Coloured virtual signals are now found based on their subgroup rather than their order.

### DIFF
--- a/prototypes/signal/final-fixes.lua
+++ b/prototypes/signal/final-fixes.lua
@@ -5,7 +5,7 @@ if DECT.ENABLED["signals"] then
 	-- Get signals and update mappings (in case some new ones are added by other mods)
 	local colors = DECT.CONFIG.SIGNALS
 	for _, signal in pairs(data.raw["virtual-signal"]) do
-		if not signal.order:find("colors") and signal.color then
+		if not (signal.subgroup == "virtual-signal-color") and signal.color then
 			table.insert(colors, {type=signal.type, name=signal.name, color=signal.color})
 		end
 	end

--- a/prototypes/signal/signals.lua
+++ b/prototypes/signal/signals.lua
@@ -14,7 +14,7 @@ if DECT.ENABLED["signals"] then
 
 	-- Clear out any existing signals that conflict
 	for name, signal in pairs(data.raw["virtual-signal"]) do
-		if signal.order:find("colors") then
+		if signal.subgroup == "virtual-signal-color" then
 			data.raw["virtual-signal"][name] = nil
 		end
 	end


### PR DESCRIPTION
I'm not sure if there was a specific reason to find conflicting signals by `order` rather than `subgroup`, but if not, this change coincidentally fixes #54.