### PR TITLE
Fix 0.8.6's migration when using Alien Biomes.

### DIFF
--- a/migrations/0.8.6.lua
+++ b/migrations/0.8.6.lua
@@ -9,9 +9,14 @@ for index, force in pairs(game.forces) do
 	if settings.startup["dectorio-waterfill"].value then
 		if tech["landfill"].researched then
 			rec["dect-base-water"].enabled = true
-			rec["dect-base-water-green"].enabled = true
 			rec["dect-base-deepwater"].enabled = true
-			rec["dect-base-deepwater-green"].enabled = true
+			
+			-- When Alien Biomes is activated, the green variations of
+			-- the water aren't created by Dectorio.
+			if not settings.startup["alien-biomes-terrain-scale"] then
+				rec["dect-base-water-green"].enabled = true
+				rec["dect-base-deepwater-green"].enabled = true
+			end
 		end
 	end
 end


### PR DESCRIPTION
When Alien Biomes is enabled, the config `BASE_WATER_TILES` is modified to have `water-green` and `deepwater-green` removed.

Value originally set in [`config.lua`](https://github.com/jpanther/Dectorio/blob/e456034514b8605da1687a1a6d096cbdb287d94f/config.lua#L131), later modified by [`prototypes/third-party/config.lua`](https://github.com/jpanther/Dectorio/blob/e456034514b8605da1687a1a6d096cbdb287d94f/prototypes/third-party/config.lua#L5).

This then causes an error in the migration script for version 0.8.6, which tries to enable the recipes that are now no longer created.

This patch is a simple fix that resolves this incompatibility.