### PR TITLE
Set decorative_removal_probability for all base tile types

### DIFF
--- a/prototypes/tile/tiles.lua
+++ b/prototypes/tile/tiles.lua
@@ -91,8 +91,14 @@ local function tile_variants_material(set, variant)
 end
 
 -- Modify decorations on base tiles
-base_stone_path.decorative_removal_probability = DECT.CONFIG.SETTINGS["decorative_removal_probability"]
-base_concrete.decorative_removal_probability = DECT.CONFIG.SETTINGS["decorative_removal_probability"]
+local decorative_removal_probability = DECT.CONFIG.SETTINGS["decorative_removal_probability"]
+base_stone_path.decorative_removal_probability = decorative_removal_probability
+base_concrete.decorative_removal_probability = decorative_removal_probability
+base_hazard_left.decorative_removal_probability = decorative_removal_probability
+base_hazard_right.decorative_removal_probability = decorative_removal_probability
+base_refined_concrete.decorative_removal_probability = decorative_removal_probability
+base_refined_hazard_left.decorative_removal_probability = decorative_removal_probability
+base_refined_hazard_right.decorative_removal_probability = decorative_removal_probability
 
 -- Add landfill tile
 local landfill = table.deepcopy(data.raw.tile["dirt-5"])


### PR DESCRIPTION
Prevent decoratives from remaining on top of the base game tiles.

![grafik](https://user-images.githubusercontent.com/1579362/50518957-d4164400-0ab8-11e9-93f4-3217687b6a24.png)

I haven't tested these changes yet.