### PR TITLE
Maintenance madness compatibility fix

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -140,7 +140,7 @@ DECT.CONFIG.BASE_WATER_TILES = {"water", "deepwater", "water-green", "deepwater-
 DECT.CONFIG.BASE_TREES = {"tree-01", "tree-02", "tree-03", "tree-04", "tree-05", "tree-06", "tree-07", "tree-08", "tree-09", "dead-dry-hairy-tree", "dead-grey-trunk", "dead-tree-desert", "dry-hairy-tree", "dry-tree", "tree-02-red", "tree-08-red", "tree-09-red", "tree-06-brown", "tree-08-brown", "tree-09-brown"}
 DECT.CONFIG.BASE_ROCKS = {"rock-huge", "rock-big", "sand-rock-big"}
 DECT.CONFIG.SIGN_CATEGORIES = {"item", "fluid", "tool", "ammo", "armor", "capsule", "gun", "module"}
-DECT.CONFIG.SIGN_BLACKLIST = {"barrel", "loader", "simple%-entity", "player%-port", "computer", "coin", "small%-plane", "railgun", "vehicle%-machine%-gun", "tank%-machine%-gun", "signpost", "dect%-signal%-", "infinity%-chest", "infinity%-pipe", "heat%-interface", "pollution", "escape%-pod%-power", "dummy%-steel%-axe", "atlas", "crash%-site", "dect%-sign", "dect%-base"}
+DECT.CONFIG.SIGN_BLACKLIST = {"mm%-faulty%-", "mm%-scrapped%-", "mm%-recycle%-", "mm%-recondition%-", "barrel", "loader", "simple%-entity", "player%-port", "computer", "coin", "small%-plane", "railgun", "vehicle%-machine%-gun", "tank%-machine%-gun", "signpost", "dect%-signal%-", "infinity%-chest", "infinity%-pipe", "heat%-interface", "pollution", "escape%-pod%-power", "dummy%-steel%-axe", "atlas", "crash%-site", "dect%-sign", "dect%-base"}
 DECT.CONFIG.SIGN_WHITELIST = {"empty-barrel"}
 
 DECT.INCOMPATIBLE = {}


### PR DESCRIPTION
This is another pr for the current issue with the maintenance madness mod (see [this mod portal issue](https://mods.factorio.com/mod/MaintenanceMadness/discussion/5db835147291ea000d27b05a) for further information). 

The issue is related to the sign symbol creation and can be **avoided by simply adding certain search strings to DECT.SIGN_BLACKLIST**. The problematic items do not have to be shown in the sign icon list anyhow.
