### PR TITLE
Update English locale dectorio.cfg to fix "unknown key" tooltip msgs.

### DIFF
--- a/locale/en/dectorio.cfg
+++ b/locale/en/dectorio.cfg
@@ -159,6 +159,21 @@ dect-traffic-bollard=Traffic bollard
 stone-wall=Stone wall
 gate=Stone gate
 dect-concrete-gate=Concrete gate
+tree-01=Tree 1
+tree-02=Tree 2
+tree-03=Tree 3
+tree-04=Tree 4
+tree-05=Tree 5
+tree-06=Tree 6
+tree-07=Tree 7
+tree-08=Tree 8
+tree-09=Tree 9
+tree-02-red=Red tree 2
+tree-08-red=Red tree 8
+tree-09-red=Red tree 9
+tree-06-brown=Brown tree 6
+tree-08-brown=Brown tree 8
+tree-09-brown=Brown tree 9
 
 [tile-name]
 dect-concrete-grid=Concrete grid


### PR DESCRIPTION
Added [entity-name] entries to prevent "unknown key" tooltip messages being shown when hovering over Dectorio tree recipes.